### PR TITLE
Italian translation for description

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
 	"i18n": [
 		"de", "en", "es", "gl", "it", "sv", "uk"
 	],
+	"package-i18n": {
+		"it": {
+			"description": "Aggiunge automaticamente i prefissi dei browser al CSS"
+		}
+    	},
 	"devDependencies": {
 		"gulp": "^3.8.6",
 		"gulp-jscs": "^1.1.0",


### PR DESCRIPTION
I saw [here](https://github.com/adobe/brackets/wiki/Release-Notes:-0.44) that the package-i18n property is now supported by package.json
